### PR TITLE
Add timestamp to download filename

### DIFF
--- a/src/ts/background/background.ts
+++ b/src/ts/background/background.ts
@@ -32,7 +32,7 @@ browser.runtime.onMessage.addListener(async (message: DownloadMessage) => {
 async function downloadSingleImage(message: DownloadMessage): Promise<void> {
     // Get the image id
     let imageName = getImageId(message.imageURL[0]);
-    imageName = `${message.accountName}_${new Date(message.timestamp*1000).toISOString().replace(/:/g, '-')}_${imageName}`;
+    imageName = `${message.accountName}_${new Date(message.timestamp[0]*1000).toISOString().replace(/:/g, '-')}_${imageName}`;
 
     await browser.downloads.download({
         url: message.imageURL[0],

--- a/src/ts/background/background.ts
+++ b/src/ts/background/background.ts
@@ -32,7 +32,7 @@ browser.runtime.onMessage.addListener(async (message: DownloadMessage) => {
 async function downloadSingleImage(message: DownloadMessage): Promise<void> {
     // Get the image id
     let imageName = getImageId(message.imageURL[0]);
-    imageName = `${message.accountName}_${imageName}`;
+    imageName = `${message.accountName}_${new Date(message.timestamp*1000).toISOString().replace(/:/g, '-')}_${imageName}`;
 
     await browser.downloads.download({
         url: message.imageURL[0],

--- a/src/ts/downloaders/AccountImageDownloader.ts
+++ b/src/ts/downloaders/AccountImageDownloader.ts
@@ -24,10 +24,12 @@ export class AccountImageDownloader extends Downloader {
         const response = await makeRequest(location.href);
         const pictureURL = response.owner.profile_pic_url_hd;
         const accountName = response.owner.username;
+        const timestamp = response.taken_at_timestamp
 
         const downloadMessage: DownloadMessage = {
             imageURL: [pictureURL],
-            accountName,
+            accountName: accountName,
+            timestamp: timestamp,
             type: DownloadType.single,
         };
         await browser.runtime.sendMessage(downloadMessage);

--- a/src/ts/downloaders/AccountImageDownloader.ts
+++ b/src/ts/downloaders/AccountImageDownloader.ts
@@ -9,7 +9,6 @@
 import { browser } from 'webextension-polyfill-ts';
 import { DownloadMessage, DownloadType } from '../modles/extension';
 import { Variables } from '../Variables';
-import { makeRequest } from './download-functions';
 import { Downloader } from './Downloader';
 
 /**
@@ -21,10 +20,10 @@ export class AccountImageDownloader extends Downloader {
      * Download the account image
      */
     private static async downloadContent(): Promise<void> {
-        const response = await makeRequest(location.href);
-        const pictureURL = response.owner.profile_pic_url_hd;
-        const accountName = response.owner.username;
-        const timestamp = 0; // response.taken_at_timestamp;
+        const response = (await (await fetch(`${location.href}?__a=1`)).json()).graphql;
+        const pictureURL = response.user.profile_pic_url_hd;
+        const accountName = response.user.username;
+        const timestamp = new Date().getTime() / 1000; // There is no timestamp for profile pictures, use the current time
 
         const downloadMessage: DownloadMessage = {
             imageURL: [pictureURL],

--- a/src/ts/downloaders/AccountImageDownloader.ts
+++ b/src/ts/downloaders/AccountImageDownloader.ts
@@ -24,12 +24,12 @@ export class AccountImageDownloader extends Downloader {
         const response = await makeRequest(location.href);
         const pictureURL = response.owner.profile_pic_url_hd;
         const accountName = response.owner.username;
-        const timestamp = response.taken_at_timestamp
+        const timestamp = 0; // response.taken_at_timestamp;
 
         const downloadMessage: DownloadMessage = {
             imageURL: [pictureURL],
             accountName: accountName,
-            timestamp: timestamp,
+            timestamp: [timestamp],
             type: DownloadType.single,
         };
         await browser.runtime.sendMessage(downloadMessage);

--- a/src/ts/downloaders/BulkDownloader.ts
+++ b/src/ts/downloaders/BulkDownloader.ts
@@ -71,6 +71,7 @@ export class BulkDownloader extends Downloader {
         const downloadMessage: DownloadMessage = {
             imageURL: mediaLinks,
             accountName: this.getAccountName(document.body, Variables.accountNameClass),
+            timestamp: 0,
             type: DownloadType.bulk,
         };
         await browser.runtime.sendMessage(downloadMessage);

--- a/src/ts/downloaders/BulkDownloader.ts
+++ b/src/ts/downloaders/BulkDownloader.ts
@@ -71,7 +71,7 @@ export class BulkDownloader extends Downloader {
         const downloadMessage: DownloadMessage = {
             imageURL: mediaLinks,
             accountName: this.getAccountName(document.body, Variables.accountNameClass),
-            timestamp: 0,
+            timestamp: [0],
             type: DownloadType.bulk,
         };
         await browser.runtime.sendMessage(downloadMessage);

--- a/src/ts/downloaders/HotkeyDownloader.ts
+++ b/src/ts/downloaders/HotkeyDownloader.ts
@@ -64,7 +64,7 @@ export class HotkeyDownloader {
         const downloadMessage: DownloadMessage = {
             imageURL: response.mediaURL,
             type: downloadType,
-            timestamp: response.original.taken_at_timestamp,
+            timestamp: [response.original.taken_at_timestamp],
             accountName: response.accountName,
         };
 

--- a/src/ts/downloaders/HotkeyDownloader.ts
+++ b/src/ts/downloaders/HotkeyDownloader.ts
@@ -64,6 +64,7 @@ export class HotkeyDownloader {
         const downloadMessage: DownloadMessage = {
             imageURL: response.mediaURL,
             type: downloadType,
+            timestamp: response.original.taken_at_timestamp,
             accountName: response.accountName,
         };
 

--- a/src/ts/downloaders/HoverDownloader.ts
+++ b/src/ts/downloaders/HoverDownloader.ts
@@ -86,7 +86,7 @@ export class HoverDownloader extends Downloader {
             const downloadMessage: DownloadMessage = {
                 imageURL: response.mediaURL,
                 accountName: response.accountName,
-                timestamp: response.original.taken_at_timestamp,
+                timestamp: [response.original.taken_at_timestamp],
                 type: DownloadType.single,
             };
             await browser.runtime.sendMessage(downloadMessage);

--- a/src/ts/downloaders/HoverDownloader.ts
+++ b/src/ts/downloaders/HoverDownloader.ts
@@ -86,6 +86,7 @@ export class HoverDownloader extends Downloader {
             const downloadMessage: DownloadMessage = {
                 imageURL: response.mediaURL,
                 accountName: response.accountName,
+                timestamp: response.original.taken_at_timestamp,
                 type: DownloadType.single,
             };
             await browser.runtime.sendMessage(downloadMessage);

--- a/src/ts/downloaders/PostDownloader.ts
+++ b/src/ts/downloaders/PostDownloader.ts
@@ -33,7 +33,7 @@ export class PostDownloader extends Downloader {
         const downloadMessage: DownloadMessage = {
             imageURL: response.mediaURL,
             accountName: response.accountName,
-            timestamp: response.original.taken_at_timestamp,
+            timestamp: [response.original.taken_at_timestamp],
             type: DownloadType.single,
         };
         await browser.runtime.sendMessage(downloadMessage);

--- a/src/ts/downloaders/PostDownloader.ts
+++ b/src/ts/downloaders/PostDownloader.ts
@@ -33,6 +33,7 @@ export class PostDownloader extends Downloader {
         const downloadMessage: DownloadMessage = {
             imageURL: response.mediaURL,
             accountName: response.accountName,
+            timestamp: response.original.taken_at_timestamp,
             type: DownloadType.single,
         };
         await browser.runtime.sendMessage(downloadMessage);

--- a/src/ts/downloaders/StoryDownloader.ts
+++ b/src/ts/downloaders/StoryDownloader.ts
@@ -42,7 +42,8 @@ export class StoryDownloader extends Downloader {
 
         const downloadMessage: DownloadMessage = {
             imageURL: [url],
-            accountName,
+            accountName: accountName,
+            timestamp: 0,
             type: DownloadType.single,
         };
         await browser.runtime.sendMessage(downloadMessage);

--- a/src/ts/downloaders/StoryDownloader.ts
+++ b/src/ts/downloaders/StoryDownloader.ts
@@ -29,6 +29,8 @@ export class StoryDownloader extends Downloader {
 
         const video = document.querySelector('video');
         const img = document.querySelector<HTMLImageElement>(Variables.storyImageClass);
+        const datetimeObj = document.querySelector('time');
+        const timestamp = datetimeObj ? new Date(datetimeObj.dateTime).getTime()/1000 : 0;
 
         log(video);
         log(img);
@@ -43,7 +45,7 @@ export class StoryDownloader extends Downloader {
         const downloadMessage: DownloadMessage = {
             imageURL: [url],
             accountName: accountName,
-            timestamp: 0,
+            timestamp: timestamp,
             type: DownloadType.single,
         };
         await browser.runtime.sendMessage(downloadMessage);

--- a/src/ts/downloaders/StoryDownloader.ts
+++ b/src/ts/downloaders/StoryDownloader.ts
@@ -45,7 +45,7 @@ export class StoryDownloader extends Downloader {
         const downloadMessage: DownloadMessage = {
             imageURL: [url],
             accountName: accountName,
-            timestamp: timestamp,
+            timestamp: [timestamp],
             type: DownloadType.single,
         };
         await browser.runtime.sendMessage(downloadMessage);

--- a/src/ts/modles/extension.ts
+++ b/src/ts/modles/extension.ts
@@ -10,7 +10,7 @@ import { ShortcodeMedia } from './post';
 export interface DownloadMessage {
     imageURL: string[];
     accountName: string;
-    timestamp: number;
+    timestamp: number[];
     type: DownloadType;
 }
 

--- a/src/ts/modles/extension.ts
+++ b/src/ts/modles/extension.ts
@@ -10,6 +10,7 @@ import { ShortcodeMedia } from './post';
 export interface DownloadMessage {
     imageURL: string[];
     accountName: string;
+    timestamp: number;
     type: DownloadType;
 }
 


### PR DESCRIPTION
I guess inspired by #125, I have always wanted to add timestamp to the downloaded files so that they can be sorted chronologically and be informative. So I added it to all downloaders, including bulk, except the profile picture does not have a timestamp so I just used the current datetime. Along the way I also fixed the profile picture downloader which wasn't working on my end.

Now the filename format is: `world_record_egg_2019-01-04T17-05-45.000Z_47692668_1958135090974774_6762833792332802352_n.jpg`

I have to replace the `:` in time with `-` because `:` is illegal in Windows paths. 

I have tested everything in Firefox but not Chrome. 

