### PR TITLE
Fixed logger decorator

### DIFF
--- a/src/ts/decorators.ts
+++ b/src/ts/decorators.ts
@@ -54,7 +54,7 @@ export function LogClassErrors(constructor: Function): void {
         if (!(method instanceof Function) || key === 'constructor') continue;
         descriptor.value = function(...args: any[]): void {
             try {
-                method.apply(this, args);
+                return method.apply(this, args);
             } catch (e) {
 
                 const issue = encodeURIComponent(`${constructor.name} ${e.toString()}`);


### PR DESCRIPTION
Right now logger wraps   function call into `try...catch` block but returns nothing.
It leads to issues with async function because code expects to have a Promise there.

```ts
function doOther(): Promise<void> {
  return Promise.resolve();
}

async function doSomething(): Promise<void> {
   await this.doOther(); // it isn't a promise
}
```