### PR TITLE
Add Referer header on download request

### DIFF
--- a/src/ts/background/download.ts
+++ b/src/ts/background/download.ts
@@ -19,6 +19,9 @@ export async function downloadSingleImage(message: DownloadMessage): Promise<voi
     await browser.downloads.download({
         url: message.imageURL[0],
         filename: imageName,
+        headers: [
+            {name: "Referer", value: "https://www.instagram.com/"},
+        ],
     });
 
 }


### PR DESCRIPTION
Fixes #165

This takes care of cross-origin-resource-policy which causes the download to fail.