### PR TITLE
fix the slow video download

### DIFF
--- a/src/build.js
+++ b/src/build.js
@@ -67,6 +67,7 @@ class BuildExtensionPlugin {
         await fs.promises.mkdir(path);
 
         await fs.promises.copyFile(`src/manifest_${browser}.json`, `${path}/manifest.json`);
+        await fs.promises.copyFile(`src/rules.json`, `${path}/rules.json`);
         await fse.copy("src/icons/", `${path}/icons`);
         await fse.copy("dist", path);
     }

--- a/src/manifest_chrome.json
+++ b/src/manifest_chrome.json
@@ -14,8 +14,16 @@
   "options_ui": {
     "page": "options.html"
   },
+  "declarative_net_request" : {
+    "rule_resources" : [{
+      "id": "rules_set_1",
+      "enabled": true,
+      "path": "rules.json"
+    }]
+  },
   "permissions": [
     "downloads",
+    "declarativeNetRequest",
     "tabs",
     "*://*.instagram.com/*",
     "*://*.cdninstagram.com/*",

--- a/src/rules.json
+++ b/src/rules.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": 1,
+    "priority": 1,
+    "action": {
+      "type": "modifyHeaders",
+      "requestHeaders": [
+        { "header": "User-Agent", "operation": "set", "value": "curl/7.64.1" }
+      ]
+    },
+    "condition": {
+      "urlFilter" : "||fbcdn.net/*",
+      "excludedDomains": ["instagram.com"],
+      "resourceTypes": ["xmlhttprequest"]
+    }
+  },
+  {
+    "id": 2,
+    "priority": 1,
+    "action": {
+      "type": "modifyHeaders",
+      "requestHeaders": [
+        { "header": "User-Agent", "operation": "set", "value": "curl/7.64.1" }
+      ]
+    },
+    "condition": {
+      "urlFilter" : "||cdninstagram.net/*",
+      "excludedDomains": ["instagram.com"],
+      "resourceTypes": ["xmlhttprequest"]
+    }
+  }
+]

--- a/src/ts/background/download.ts
+++ b/src/ts/background/download.ts
@@ -54,7 +54,11 @@ export async function downloadBulk(urls: string[], accountName: string): Promise
     const zip: JSZip = new JSZip();
     for (const [imageIndex, url] of urls.entries()) {
         try {
-            const response = await fetch(url);
+            const response = await fetch(url, {
+                headers: {
+                    'User-Agent': 'curl/7.64.1',
+                }
+            });
             zip.file(getImageId(url), await response.blob(), {binary: true});
         } catch (e) {
             const blob = new Blob([


### PR DESCRIPTION
This PR fix the slow down video download for Chrome using [declarativeNetRequest](https://developer.chrome.com/docs/extensions/reference/declarativeNetRequest/) and modifying the user agent for requests that are not initiated from instagram.com.

For Firefox, using only the fetch api to change the request headers works.
This not work for Chrome due to a [bug in chromium](https://bugs.chromium.org/p/chromium/issues/detail?id=571722).