### PR TITLE
Add mobile story download support

### DIFF
--- a/src/ts/QuerySelectors.ts
+++ b/src/ts/QuerySelectors.ts
@@ -21,6 +21,7 @@ export enum QuerySelectors {
     // Story
     storyImage = '.y-yJ5',
     storyCloseButton = '.K_10X',
+    storyCloseButtonMobile = '._g3zU',
 
     // Account, Hover, Explore, Reels
     imagePreview = '._bz0w, .pKKVh, .Tjpra > a',

--- a/src/ts/downloaders/StoryDownloader.ts
+++ b/src/ts/downloaders/StoryDownloader.ts
@@ -54,7 +54,10 @@ export class StoryDownloader extends Downloader {
      * Create a new download button
      */
     public createDownloadButton(): void {
-        const closeButton: HTMLElement = document.querySelector(QuerySelectors.storyCloseButton) as HTMLElement;
+        let closeButton: HTMLElement = document.querySelector(QuerySelectors.storyCloseButton) as HTMLElement;
+
+        // The close button class is different on mobile
+        if (!closeButton) closeButton = document.querySelector(QuerySelectors.storyCloseButtonMobile) as HTMLElement;
 
         // Check if the story has already loaded
         if (!closeButton) return;


### PR DESCRIPTION
On Firefox mobile when story is displayed the download icon is not displayed. This is because it checks for `storyCloseButton = '.K_10X'` which somehow only exists for desktop site but not the mobile site. On mobile the equivalent is (what I added) `'._g3zU'`. 

My approach right now is if `if (!closeButton)` (does not exist) then check again using the mobile class. The fix is really quite simple and feel free to re-implement it with the style guide of the project and TypeScript.

I tested that this works on Firefox Android 68.12.0esr, the latest mobile version with full support for Web Extensions. In the latest Firefox Android nightly the fix also works as intended but [latest Firefox is yet to add back in support for `browser.downloads`](https://bugzilla.mozilla.org/show_bug.cgi?id=1538348) (maybe this could be something to think about too... for single image maybe open the URL in a new tab). An alternative way to check that the button is correctly appearing is to simulate a mobile device resolution and UA on desktop browser console. 
