### PR TITLE
Fix InstaID precision without using bigint

### DIFF
--- a/src/ts/functions.ts
+++ b/src/ts/functions.ts
@@ -61,19 +61,15 @@ export const shortcodeToInstaID = (shortcode: string): string => {
     let id_tri = 0;
     let id_num = 0;
     for (const char of shortcode) {
-        if (id_num > c_tri) {
+        id_tri *= 64;
+        id_num = (id_num * 64) + alphabet.indexOf(char);
+        if (id_num >= c_tri) {
             let quot = Math.floor(id_num / c_tri);
             id_tri += quot;
             id_num -= quot * c_tri;
         }
-        id_tri *= 64;
-        id_num = (id_num * 64) + alphabet.indexOf(char);
     }
-    id_tri = id_tri > 0 ? id_tri + c_tri.toString().substring(1) : "";
-    let id_p1 = id_tri.slice(0,-id_num.toString().length-2);
-    let id_p2 = (Number(id_tri.substring(id_p1.length)) + id_num).toString();
-
-    return id_p1 + id_p2;
+    return (id_tri.toString() + id_num.toString().padStart(c_tri.toString().length - 1, '0')).replace(/^0+/, "");
 };
 
 export const instaIDToTimestamp = (id: string) => {

--- a/src/ts/functions.ts
+++ b/src/ts/functions.ts
@@ -55,18 +55,29 @@ export const shortcodeToDateString = (shortcode: string): string =>
         shortcodeToInstaID(shortcode),
     );
 
-export const shortcodeToInstaID = (shortcode: string): number => {
+export const shortcodeToInstaID = (shortcode: string): string => {
     const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
-    let id = 0;
+    const c_tri = 1000000000000;
+    let id_tri = 0;
+    let id_num = 0;
     for (const char of shortcode) {
-        id = (id * 64) + alphabet.indexOf(char);
+        if (id_num > c_tri) {
+            let quot = Math.floor(id_num / c_tri);
+            id_tri += quot;
+            id_num -= quot * c_tri;
+        }
+        id_tri *= 64;
+        id_num = (id_num * 64) + alphabet.indexOf(char);
     }
+    id_tri = id_tri > 0 ? id_tri + c_tri.toString().substring(1) : "";
+    let id_p1 = id_tri.slice(0,-id_num.toString().length-2);
+    let id_p2 = (Number(id_tri.substring(id_p1.length)) + id_num).toString();
 
-    return id;
+    return id_p1 + id_p2;
 };
 
-export const instaIDToTimestamp = (id: number) => {
-    const timestamp = (id / Math.pow(2, 23)) + 1314220021721;
+export const instaIDToTimestamp = (id: string) => {
+    const timestamp = (Number(id) / Math.pow(2, 23)) + 1314220021721;
 
     return new Date(timestamp).toLocaleString();
 };


### PR DESCRIPTION
With this patch you return the real InstaID, if needed to be checked or used for something else. The one returned now is not precise.