### PR TITLE
Fix InstaID precision without using bigint

### DIFF
--- a/src/ts/functions.ts
+++ b/src/ts/functions.ts
@@ -55,18 +55,25 @@ export const shortcodeToDateString = (shortcode: string): string =>
         shortcodeToInstaID(shortcode),
     );
 
-export const shortcodeToInstaID = (shortcode: string): number => {
+export const shortcodeToInstaID = (shortcode: string): string => {
     const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
-    let id = 0;
+    const c_tri = 1000000000000;
+    let id_tri = 0;
+    let id_num = 0;
     for (const char of shortcode) {
-        id = (id * 64) + alphabet.indexOf(char);
+        id_tri *= 64;
+        id_num = (id_num * 64) + alphabet.indexOf(char);
+        if (id_num >= c_tri) {
+            let quot = Math.floor(id_num / c_tri);
+            id_tri += quot;
+            id_num -= quot * c_tri;
+        }
     }
-
-    return id;
+    return (id_tri.toString() + id_num.toString().padStart(c_tri.toString().length - 1, '0')).replace(/^0+/, "");
 };
 
-export const instaIDToTimestamp = (id: number) => {
-    const timestamp = (id / Math.pow(2, 23)) + 1314220021721;
+export const instaIDToTimestamp = (id: string) => {
+    const timestamp = (Number(id) / Math.pow(2, 23)) + 1314220021721;
 
     return new Date(timestamp).toLocaleString();
 };

--- a/src/ts/functions.ts
+++ b/src/ts/functions.ts
@@ -57,18 +57,14 @@ export const shortcodeToDateString = (shortcode: string): string =>
 
 export const shortcodeToInstaID = (shortcode: string): string => {
     /* Instagram changed the shortcode generation method at 2012-02-07
-          2012-02-07T02:01:16.000Z --> o5H__
-          2012-02-07T02:35:23.000Z --> GsBiMipBgr
-       With a low margin of error, we can assume the change happened 2:30:00 GMT
-       GsA6wzgAAA = 120475328165445632
+          2012-02-07T02:01:16.000Z --> o5H__       (old: sequential)
+          2012-02-07T02:35:23.000Z --> GsBiMipBgr  (new: timestamp derived)
+          2290-05-20T12:17:23.928Z --> ___________ (last possible shortcode with 11 characters)
     */
-    if (shortcode.length < 10) return ''; // support new shortcode method only
-    
-    /* Private account shortcodes problem:
-       - How many characters to extract from private account shortcode?
-         Old method shortcode length is 1 until 5, new method length can be 10 or 11
-    */
-    if (shortcode.length > 11) return ''; // TODO: handle private account shortcodes
+
+    if (shortcode.length > 28) shortcode = shortcode.slice(0, -28); // handle private account shortcodes
+
+    if (shortcode.length < 10 || shortcode.length > 11) return ''; // support new shortcode method only
 
     const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
     const cMil = 1000000; // add 6 digits of precision to the Number max limit (safe at least until year 2290)


### PR DESCRIPTION
With this patch you return the real InstaID, if needed to be checked or used for something else. The one returned now is not precise.